### PR TITLE
check_prometheus_metric.sh: redir stderr to stdout

### DIFF
--- a/check_prometheus_metric.sh
+++ b/check_prometheus_metric.sh
@@ -136,7 +136,7 @@ function get_prometheus_result {
                             "$PROMETHEUS_SERVER" \
                             "$PROMETHEUS_TIMEOUT"
 
-  _RESULT=$( $_PROMETHEUS_CMD "$PROMETHEUS_QUERY" )
+  _RESULT=$( $_PROMETHEUS_CMD "$PROMETHEUS_QUERY" 2>&1 )
 
   # check result
   if [[ $_RESULT =~ ^[0-9]+\.?[0-9]*$ ]]


### PR DESCRIPTION
This is so we can more easily debug problems in script execution.
