### PR TITLE
Eliminate the need for the deprecated Prometheus CLI

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,24 @@
 # nagios_plugins
 
-nagios plugins for alerting on prometheus query results
+Nagios plugin (in fact only one) for alerting on prometheus query results.
+
+You need to add the following commands to your Nagios configuration to use it:
+```
+define command {
+    command_name check_prometheus
+    command_line $USER1$/check_prometheus_metric.sh -H '$ARG1$' -q '$ARG2$' -w '$ARG3$' -c '$ARG4$' -n '$ARG5$' -m '$ARG6$'
+}
+
+# check_prometheus, treating a NaN result as ok
+define command {
+    command_name check_prometheus_nan_ok
+    command_line $USER1$/check_prometheus_metric.sh -H '$ARG1$' -q '$ARG2$' -w '$ARG3$' -c '$ARG4$' -n '$ARG5$' -m '$ARG6$' -O
+}
+```
+
+The [`curl`](https://curl.haxx.se/) and the
+[`jq`](https://stedolan.github.io/jq/) command must be installed for the plugin
+to work.
 
 ## Usage
 


### PR DESCRIPTION
This uses a combination of curl and jq instead.

Also, remove the 'in single quote' notes from the usage description,
because it is actually not true. Surely, you will set the single
quotes on the shell command line, but they are stripped off by the
shell. If you actually passed in single quotes (as in
`-H "'http://localhost'"`), things would break badly, even before
this change.

@fabxc FYI
@matthiasr for shell foo