### PR TITLE
check_prometheus_metric.sh: fetch response from 'value' object

### DIFF
--- a/check_prometheus_metric.sh
+++ b/check_prometheus_metric.sh
@@ -134,7 +134,7 @@ function get_prometheus_result {
 
   local _RESULT
 
-  _RESULT=$( ${CURL} -sgG --data-urlencode "query=${PROMETHEUS_QUERY}" "${PROMETHEUS_SERVER}/api/v1/query" | $JQ -r '.data.result[1]' )
+  _RESULT=$( ${CURL} -sgG --data-urlencode "query=${PROMETHEUS_QUERY}" "${PROMETHEUS_SERVER}/api/v1/query" | $JQ -r '.data.result[0].value[1]' )
 
   # check result
   if [[ ${_RESULT} =~ ^-?[0-9]+\.?[0-9]*$ ]]


### PR DESCRIPTION
Latest Prometheus version return metric value in a nested 'value' object.

I tried locally with prometheus 1.0.1 and got UNKNOWN:

```
./check_prometheus_metric.sh -H http://localhost:9090  -q up -w 0 -c 0 -n up
UNKNOWN - unable to parse prometheus response
up is {
  "metric": {
    "__name__": "up",
    "instance": "localhost:9100",
    "job": "node"
  },
  "value": [
    1472203100.018,
    "1"
  ]
}
```