### PR TITLE
Adding checks for commands that might not be installed on the systems…

### DIFF
--- a/check_prometheus_metric.sh
+++ b/check_prometheus_metric.sh
@@ -7,9 +7,9 @@
 export LC_ALL=C
 
 # Default configuration:
-CURL=curl
+CURL=$(which curl) || { echo 'Unable to find path for curl. Please install jq and ensure it is in your $PATH' ; exit 2 ; }
 ECHO=echo
-JQ=jq
+JQ=$(which jq) || { echo 'Unable to find path for jq. Please install jq and ensure it is in your $PATH' ; exit 2 ; }
 XARGS=xargs
 COMPARISON_METHOD=ge
 NAN_OK="false"


### PR DESCRIPTION
….  Exit 2 so that Nagios marks it as critical.

Just trying to make it clear for the person who runs it that commands aren't in their path. @beorn7 