### PR TITLE
Allow ssl

### DIFF
--- a/check_prometheus_metric.sh
+++ b/check_prometheus_metric.sh
@@ -45,6 +45,7 @@ function usage {
     -i               Print the extra metric information into the Nagios message.
     -t QUERY_TYPE    Prometheus query return type: scalar (default) or vector.
                      The first element of the vector is used for the check.
+    -C CARCERT       TLS certificate
 
 EoL
 }
@@ -52,7 +53,7 @@ EoL
 
 function process_command_line {
 
-  while getopts ':H:q:w:c:m:n:Oit:' OPT "$@"
+  while getopts ':H:q:w:c:m:n:OitC:' OPT "$@"
   do
     case ${OPT} in
       H)        PROMETHEUS_SERVER="$OPTARG" ;;
@@ -103,6 +104,9 @@ function process_command_line {
                   NAGIOS_LONG_TEXT="$(usage)"
                   exit
                 fi
+                ;;
+
+      C)        CACERT="$OPTARG"
                 ;;
 
       \?)       NAGIOS_SHORT_TEXT="invalid option: -$OPTARG"
@@ -158,7 +162,7 @@ function get_prometheus_raw_result {
 
   local _RESULT
 
-  _RESULT=$( ${CURL} -ksgG --data-urlencode "query=${PROMETHEUS_QUERY}" "${PROMETHEUS_SERVER}/api/v1/query" | $JQ -r '.data.result' )
+  _RESULT=$( ${CURL} --cacert ${CACERT} -sgG --data-urlencode "query=${PROMETHEUS_QUERY}" "${PROMETHEUS_SERVER}/api/v1/query" | $JQ -r '.data.result' )
   printf '%s' "${_RESULT}"
 
 }

--- a/check_prometheus_metric.sh
+++ b/check_prometheus_metric.sh
@@ -222,7 +222,7 @@ then
 else
     PROMETHEUS_VALUE=$( get_prometheus_vector_value "$PROMETHEUS_RAW_RESULT" )
     PROMETHEUS_RESULT=$( get_prometheus_scalar_result "$PROMETHEUS_VALUE" )
-    PROMETHEUS_METRIC=$( get_prometheus_vector_metric "$PROMETHEUS_RAW_RESULT" ) 
+    PROMETHEUS_METRIC=$( get_prometheus_vector_metric "$PROMETHEUS_RAW_RESULT" )
 fi
 
 # check the value
@@ -245,7 +245,7 @@ else
   then
     NAGIOS_STATUS=OK
     NAGIOS_SHORT_TEXT="${METRIC_NAME} is ${PROMETHEUS_RESULT}"
-  else    
+  else
     NAGIOS_SHORT_TEXT="unable to parse prometheus response"
     NAGIOS_LONG_TEXT="${METRIC_NAME} is ${PROMETHEUS_RESULT}"
   fi

--- a/check_prometheus_metric.sh
+++ b/check_prometheus_metric.sh
@@ -158,7 +158,7 @@ function get_prometheus_raw_result {
 
   local _RESULT
 
-  _RESULT=$( ${CURL} -sgG --data-urlencode "query=${PROMETHEUS_QUERY}" "${PROMETHEUS_SERVER}/api/v1/query" | $JQ -r '.data.result' )
+  _RESULT=$( ${CURL} -ksgG --data-urlencode "query=${PROMETHEUS_QUERY}" "${PROMETHEUS_SERVER}/api/v1/query" | $JQ -r '.data.result' )
   printf '%s' "${_RESULT}"
 
 }


### PR DESCRIPTION
I can only access my prometheus endpoint using ssl, and noticed the script does not support this, so I had to manually add the -k flag to the curl command.
This felt a little unsafe, so I wrote a way to add the `--cacert` flag to the command.
@beorn7  WDYT?