### PR TITLE
Swap CURL_OPTS position in curl call

### DIFF
--- a/check_prometheus_metric.sh
+++ b/check_prometheus_metric.sh
@@ -169,7 +169,7 @@ function get_prometheus_raw_result {
 
   local _RESULT
 
-  _RESULT=$(curl -sgG --data-urlencode ${CURL_OPTS} "query=${PROMETHEUS_QUERY}" "${PROMETHEUS_SERVER}/api/v1/query" | jq -r '.data.result')
+  _RESULT=$(curl -sgG ${CURL_OPTS} --data-urlencode "query=${PROMETHEUS_QUERY}" "${PROMETHEUS_SERVER}/api/v1/query" | jq -r '.data.result')
   printf '%s' "${_RESULT}"
 
 }


### PR DESCRIPTION
It was sitting between --data-urlencode and its argument, so if you
specified anything here it would try to encode the contents of CURL_OPTS
and would pass the 'query=...' as the URL to fetch.

Signed-off-by: L. Alberto Giménez <alberto.gimenez@capside.com>