### PR TITLE
Allow arbitrary headers to be passed to curl

### DIFF
--- a/README.md
+++ b/README.md
@@ -61,6 +61,9 @@ to work.
         -n NAME          A name for the metric being checked
         -m METHOD        Comparison method, one of gt, ge, lt, le, eq, ne
                          (defaults to ge unless otherwise specified)
+        -C CURL_OPTS     Additional flags to pass to curl.
+                         Can be passed multiple times. Options and option values must be passed separately.
+                         e.g. -C --conect-timetout -C 10 -C --cacert -C /path/to/ca.crt
         -O               Accept NaN as an "OK" result 
         -i               Print the extra metric information into the Nagios message
         -t QUERY_TYPE    Prometheus query return type: scalar (default) or vector.

--- a/check_prometheus_metric.sh
+++ b/check_prometheus_metric.sh
@@ -7,7 +7,7 @@
 export LC_ALL=C
 
 # Default configuration:
-CURL_OPTS=""
+CURL_OPTS=()
 COMPARISON_METHOD=ge
 NAN_OK="false"
 NAGIOS_INFO="false"
@@ -98,7 +98,7 @@ function process_command_line {
                 fi
                 ;;
 
-      C)        CURL_OPTS="${OPTARG}"
+      C)        CURL_OPTS+=("${OPTARG}")
                 ;;
       O)        NAN_OK="true"
                 ;;
@@ -169,7 +169,7 @@ function get_prometheus_raw_result {
 
   local _RESULT
 
-  _RESULT=$(curl -sgG ${CURL_OPTS} --data-urlencode "query=${PROMETHEUS_QUERY}" "${PROMETHEUS_SERVER}/api/v1/query" | jq -r '.data.result')
+  _RESULT=$(curl -sgG "${CURL_OPTS[@]}" --data-urlencode "query=${PROMETHEUS_QUERY}" "${PROMETHEUS_SERVER}/api/v1/query" | jq -r '.data.result')
   printf '%s' "${_RESULT}"
 
 }

--- a/check_prometheus_metric.sh
+++ b/check_prometheus_metric.sh
@@ -50,6 +50,8 @@ function usage {
     -m METHOD        Comparison method, one of gt, ge, lt, le, eq, ne.
                      (Defaults to ge unless otherwise specified.)
     -C CURL_OPTS     Additional flags to pass to curl.
+                     Can be passed multiple times. Options and option values must be passed separately.
+                     e.g. -C --conect-timetout -C 10 -C --cacert -C /path/to/ca.crt
     -O               Accept NaN as an "OK" result .
     -i               Print the extra metric information into the Nagios message.
     -t QUERY_TYPE    Prometheus query return type: scalar (default) or vector.


### PR DESCRIPTION
One of the Prometheus instances which should be used as a source for this script, has restricted. An access token is required to be sent with the `Authentication` header. The first naiv approach was:

````bash
export PROMETHEUS_SERVER=https://…
export PROMETHEUS_QUERY=scalar(…)
export TOKEN=******
check_prometheus_metric.sh -H $PROMETHEUS_SERVER -C "-H 'Authorization: Bearer $TOKEN'" -q $PROMETHEUS_QUERY -w 1 -c 1 -n $PROMETHEUS_QUERY
````

This did not work as the quotation around the header got messed up and an invalid header got sent to the server. From what I understand this is coming from bash and I was not able to find anything to prevent bash from messing with the quotation.

The solution I came up is handling the `-C` option as an array allowing it to be defined multiple times. The above example will the work as follow:

````bash
export PROMETHEUS_SERVER=https://…
export PROMETHEUS_QUERY=scalar(…)
export TOKEN=******
check_prometheus_metric.sh -H $PROMETHEUS_SERVER -C -H -C "Authorization: Bearer $TOKEN" -q $PROMETHEUS_QUERY -w 1 -c 1 -n $PROMETHEUS_QUERY
````

The downside is that something like `-C "--cacert /path/to/file.crt"` now needs to be passed as `-C --cacert -C /path/to/file.crt` which might brake existing setups.

Am I missing some important part here?

If this PR does not fit, please hint me into a suitable direction and I will work on that.